### PR TITLE
Update engine rule to allow for more modern versions of node

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "winston-sns",
   "description": "A Simple Notification System Transport for winston (http://www.github.com/flatiron/winston)",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "author": "Jesse Ditson <jesse.ditson@gmail.com>",
   "contributors": [
     "Matt Bowman <mbowman@yext.com>"
@@ -38,6 +38,6 @@
     "test": "vows test/*-test.js --spec"
   },
   "engines": {
-    "node": "0.4.x"
+    "node": ">=0.4.x"
   }
 }


### PR DESCRIPTION
@jesseditson We are trying to use your library with yarn and it's much more strict about the engine rule.  As a workaround, we can do `yarn install --ignore-engines` but it seems more correct to update the engine rule in this library.