### PR TITLE
allow all compatible aws-sdk releases, instead of pegging to 2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "notification"
   ],
   "dependencies": {
-    "aws-sdk": "2.1.x",
+    "aws-sdk": "^2.1.x",
     "lodash.defaults": "3.1.x"
   },
   "devDependencies": {


### PR DESCRIPTION
In particular, support for using IAM roles authentication in an ECS task has only been available since v2.4.7.