### PR TITLE
Move aws-sdk to peerDependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ An Amazon SNS transport for [winston][0].
 ```
 (or add it to your package.json)
 
+If you are running in an environment where `aws-sdk` is not installed globally, you might need to also install `aws-sdk`.
+
+``` sh
+  $ npm install aws-sdk
+```
+
 ## Usage
 ``` js
   var winston = require('winston'),

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "winston-sns",
   "description": "A Simple Notification System Transport for winston (http://www.github.com/flatiron/winston)",
-  "version": "0.2.4",
+  "version": "0.3.0",
   "author": "Jesse Ditson <jesse.ditson@gmail.com>",
   "contributors": [
     "Matt Bowman <mbowman@yext.com>"
@@ -20,10 +20,10 @@
     "notification"
   ],
   "dependencies": {
-    "aws-sdk": "^2.1.x",
     "lodash.defaults": "3.1.x"
   },
   "devDependencies": {
+    "aws-sdk": "^2.1.x",
     "winston": "0.4.x",
     "vows": "0.5.x",
     "matchdep": "0.3.x",
@@ -32,6 +32,9 @@
     "grunt-contrib-clean": "0.5.x",
     "grunt-coffeelint": "0.0.x",
     "grunt": "0.4.x"
+  },
+  "peerDependencies": {
+    "aws-sdk": "^2.1.x"
   },
   "main": "./lib/winston-sns",
   "scripts": {


### PR DESCRIPTION
Moves `aws-sdk` from `dependencies` and into `devDependencies` and `peerDependencies`.

closes #11 